### PR TITLE
Add prediction endpoint and service

### DIFF
--- a/src/main/java/com/hackathon/ibm/controller/PredictionController.java
+++ b/src/main/java/com/hackathon/ibm/controller/PredictionController.java
@@ -1,0 +1,23 @@
+package com.hackathon.ibm.controller;
+
+import com.hackathon.ibm.dto.PredictionResponse;
+import com.hackathon.ibm.service.PredictionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/predict")
+@RequiredArgsConstructor
+public class PredictionController {
+    private final PredictionService predictionService;
+
+    @PostMapping
+    public PredictionResponse predict(@RequestBody Map<String, Object> features) {
+        return predictionService.predict(features);
+    }
+}

--- a/src/main/java/com/hackathon/ibm/dto/PredictionResponse.java
+++ b/src/main/java/com/hackathon/ibm/dto/PredictionResponse.java
@@ -1,0 +1,29 @@
+package com.hackathon.ibm.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PredictionResponse {
+    private String prediction;
+
+    @JsonProperty("risk_score")
+    private Double riskScore;
+
+    @JsonProperty("top_shap_features")
+    private Map<String, Double> topShapFeatures;
+
+    @JsonProperty("firewall_recommendations")
+    private List<String> firewallRecommendations;
+}

--- a/src/main/java/com/hackathon/ibm/service/PredictionService.java
+++ b/src/main/java/com/hackathon/ibm/service/PredictionService.java
@@ -1,0 +1,51 @@
+package com.hackathon.ibm.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hackathon.ibm.dto.PredictionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PredictionService {
+    private final ObjectMapper objectMapper;
+
+    public PredictionResponse predict(Map<String, Object> features) {
+        try {
+            String inputJson = objectMapper.writeValueAsString(features);
+            ProcessBuilder processBuilder = new ProcessBuilder("python3", "inference.py");
+            Process process = processBuilder.start();
+
+            try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(process.getOutputStream()))) {
+                writer.write(inputJson);
+                writer.flush();
+            }
+
+            String output;
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                output = reader.lines().collect(Collectors.joining());
+            }
+
+            String error;
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+                error = reader.lines().collect(Collectors.joining());
+            }
+
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw new RuntimeException("Python inference failed: " + error);
+            }
+
+            return objectMapper.readValue(output, PredictionResponse.class);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to invoke prediction process", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `/api/predict` controller to accept feature payloads
- create `PredictionService` invoking a Python inference script via `ProcessBuilder`
- define `PredictionResponse` DTO capturing prediction, risk score, SHAP features and firewall recommendations

## Testing
- `mvn -o test` *(fails: Non-resolvable parent POM; network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893ece5978c832d959873d8c00c56e4